### PR TITLE
Share per-project config across git worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ include $M/claude.mk
 NONO-GLOBAL-MK := $(NONO_CLAUDE_ROOT)/NONO.mk
 -include $(NONO-GLOBAL-MK)
 
-NONO-PROJECT-MK := $(NONO_CLAUDE_ROOT)/config/$(CURDIR)/NONO.mk
+NONO_CLAUDE_BASE ?= $(CURDIR)
+NONO-PROJECT-MK := $(NONO_CLAUDE_ROOT)/config$(NONO_CLAUDE_BASE)/NONO.mk
 -include $(NONO-PROJECT-MK)
 
 include $M/shell.mk

--- a/bin/nono-claude
+++ b/bin/nono-claude
@@ -39,7 +39,9 @@ setup() {
 
   root=$NONO_CLAUDE_ROOT
   share=$root/share
-  base=$(pwd -P)
+  cwd=$(pwd -P)
+  base=$(get-project-base)
+  export NONO_CLAUDE_BASE=$base
   args=()
   update=false
   config=false
@@ -62,7 +64,7 @@ setup() {
   [[ -d $config_dir ]] || mkdir -p "$config_dir"
 
   claude_md_file=$config_dir/CLAUDE.md
-  claude_md_link=$base/CLAUDE.md
+  claude_md_link=$cwd/CLAUDE.md
 
   nono_mk_file=$config_dir/NONO.mk
 
@@ -89,8 +91,30 @@ do-claude-md() (
   fi
 )
 
+get-project-base() {
+  local common bare
+  if ! common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+    pwd -P
+    return
+  fi
+  # Non-bare repos always have common dir named `.git` (inside the
+  # project). A bare repo is its own project dir. Check `core.bare` as
+  # the primary signal — `git rev-parse --is-bare-repository` answers
+  # for the current worktree, which is always false from a linked
+  # worktree of a bare repo — and fall back to the basename heuristic
+  # for bare repos missing the setting.
+  bare=$(git config --file="$common/config" --get core.bare 2>/dev/null || true)
+  if [[ $bare == true || $(basename "$common") != .git ]]; then
+    echo "$common"
+  else
+    (cd "$common/.." && pwd -P)
+  fi
+}
+
 run() ( set -x; "$@" )
 
 die() { printf "%s\n" Error: "$@" >&2; exit 1; }
 
-main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/test/worktree-base.sh
+++ b/test/worktree-base.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Tests that get-project-base returns a stable path across git worktrees
+# of the same repo (issue #1).
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+root=$(cd "$here/.." && pwd -P)
+
+# Source the script without running main.
+# shellcheck disable=SC1091
+source "$root/bin/nono-claude"
+
+tmp=$(mktemp -d)
+trap 'rm -fr "$tmp"' EXIT
+
+fail=0
+
+assert-eq() {
+  local label=$1 expected=$2 actual=$3
+  if [[ $expected == "$actual" ]]; then
+    echo "ok - $label"
+  else
+    echo "FAIL - $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    fail=1
+  fi
+}
+
+# Case 1: outside any git repo, falls back to pwd -P.
+# GIT_CEILING_DIRECTORIES stops git from walking above $tmp, so a tmp
+# dir that happens to live inside another repo (e.g. when TMPDIR lives
+# inside a checkout) does not leak into the result.
+plain=$tmp/plain
+mkdir -p "$plain"
+actual=$(cd "$plain" && GIT_CEILING_DIRECTORIES=$tmp get-project-base)
+assert-eq "outside git repo -> pwd -P" "$plain" "$actual"
+
+# Case 2: main worktree of a regular repo.
+main_wt=$tmp/main
+mkdir -p "$main_wt"
+(
+  cd "$main_wt"
+  git init -q -b main
+  git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+)
+actual=$(cd "$main_wt" && get-project-base)
+assert-eq "main worktree -> main path" "$main_wt" "$actual"
+
+# Case 3: linked worktree of the same repo.
+feat_wt=$tmp/feat
+(cd "$main_wt" && git worktree add -q "$feat_wt" -b feat)
+actual=$(cd "$feat_wt" && get-project-base)
+assert-eq "linked worktree -> main path" "$main_wt" "$actual"
+
+# Case 4: linked worktree of a bare repo.
+bare=$tmp/bare.git
+git init -q --bare -b main "$bare"
+# Need a commit in the bare repo for worktree add to work.
+seed=$tmp/seed
+git clone -q "$bare" "$seed" 2>/dev/null
+(cd "$seed" && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init && git push -q origin main)
+bare_wt=$tmp/bare-wt
+(cd "$bare" && git worktree add -q "$bare_wt" main)
+actual=$(cd "$bare_wt" && get-project-base)
+assert-eq "bare-repo worktree -> bare repo path" "$bare" "$actual"
+
+# Case 5: subdirectory of main worktree still resolves to main worktree.
+mkdir -p "$main_wt/sub/dir"
+actual=$(cd "$main_wt/sub/dir" && get-project-base)
+assert-eq "subdir of worktree -> main path" "$main_wt" "$actual"
+
+# End-to-end: setup's $config_dir from the main and linked worktrees
+# must agree and must use the main worktree's path. This catches
+# regressions where get-project-base is correct but config_dir is wired
+# to the wrong variable.
+fake_root=$tmp/nono-root
+mkdir -p "$fake_root/share"
+cp "$root/share/NONO.mk" "$fake_root/share/"
+touch "$fake_root/Makefile"
+export NONO_CLAUDE_ROOT=$fake_root
+
+get-config-dir() {
+  bash -c 'source "$1"; setup; echo "$config_dir"' _ "$root/bin/nono-claude"
+}
+main_cfg=$(cd "$main_wt" && get-config-dir)
+feat_cfg=$(cd "$feat_wt" && get-config-dir)
+
+# Case 6: config_dir matches across worktrees.
+assert-eq "config_dir matches across worktrees" "$main_cfg" "$feat_cfg"
+
+# Case 7: config_dir uses main worktree identity, not the linked worktree.
+assert-eq "config_dir uses main worktree path" \
+  "$fake_root/config${main_wt}" "$main_cfg"
+
+exit $fail


### PR DESCRIPTION
Closes #1

## Summary
- `get-project-base` in `bin/nono-claude` resolves project identity via `git rev-parse --git-common-dir` (parent for non-bare repos, dir itself for bare repos), falling back to `pwd -P` outside git. Every worktree of the same repo now sees the same `opts_dir` / `CLAUDE.md` / `NONO.mk`.
- `Makefile` reads the same identity from a new exported `NONO_CLAUDE_BASE`, with a `$(CURDIR)` fallback when `make` is invoked directly.
- `claude_md_link` is intentionally kept per-worktree (`$cwd/CLAUDE.md`) so each worktree symlinks the shared file.

## Bare-repo handling
`git rev-parse --is-bare-repository` returns `false` from a linked worktree of a bare repo, so the function reads `core.bare` from the common dir's own config instead. A `basename != .git` secondary signal catches hand-crafted bare repos missing the setting.

## Testing
- New `test/worktree-base.sh` covers: outside-git, main worktree, linked worktree, bare-repo worktree, subdir of worktree, end-to-end `--config` agreement across worktrees, and `--config` identity under the main worktree's path (7 assertions).
- Verified the suite fails on a deliberately broken implementation (pwd-only `get-project-base`) before restoring the fix.

## Test plan
- [ ] `bash test/worktree-base.sh` (all 7 pass)
- [ ] From a linked worktree: `nono-claude --config` points at the main worktree's config dir
- [ ] From a bare-repo linked worktree: `nono-claude --config` points at the bare repo dir

Generated with [Claude Code](https://claude.com/claude-code)