### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - run: bash test/worktree-base.sh


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` to run `test/worktree-base.sh` in CI.
- Triggers on push-to-main and on pull requests.
- Uses `actions/checkout@v6.0.2`.

## Test plan
- [ ] Workflow runs on this PR and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)